### PR TITLE
Fix evaluation scripts error: replace use_auth_token with token (fixes #18)

### DIFF
--- a/evaluate/evaluate_on_hf_dataset.py
+++ b/evaluate/evaluate_on_hf_dataset.py
@@ -86,7 +86,7 @@ def main(args):
         args.dataset,
         args.config,
         split=args.split,
-        use_auth_token=True,
+        token=True,
     )
 
     text_column_name = get_text_column_names(dataset.column_names)

--- a/evaluate/jax_evaluate_on_hf_dataset.py
+++ b/evaluate/jax_evaluate_on_hf_dataset.py
@@ -83,7 +83,7 @@ def main(args):
         args.dataset,
         args.config,
         split=args.split,
-        use_auth_token=True,
+        token=True,
     )
 
     text_column_name = get_text_column_names(dataset.column_names)


### PR DESCRIPTION
The following PR fixes the issue #18 , which is caused by the deprecation of the parameter `use_auth_token` (replaced by `token`)

Thanks!!